### PR TITLE
Fix typo in bulk-importer.md

### DIFF
--- a/dashboard/bulk-importer.md
+++ b/dashboard/bulk-importer.md
@@ -20,7 +20,7 @@ Placing the content at these directories following the [parsing formats](#parsin
 | parse-albums/ | [Top-level folders as albums](#top-level-folders-as-albums)   |
 | no-parse/     | [No folder parsing](#no-parse)                                |
 
-👉 Go to `dashboard/bulk` to review importing jobs.
+👉 Go to `dashboard/bulk-importer` to review importing jobs.
 
 ### Charset
 


### PR DESCRIPTION
There is a small typo in the docs (incomplete path).